### PR TITLE
Add pre-commit hook for linting

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,15 @@
   language: swift
   types: [swift]
   require_serial: true
+- id: swift-lint
+  name: swift-lint
+  entry: swift-format lint
+  language: swift
+  types: [swift]
+  require_serial: true
+- id: swift-lint-strict
+  name: swift-lint-strict
+  entry: swift-format lint --strict
+  language: swift
+  types: [swift]
+  require_serial: true


### PR DESCRIPTION
- `swift-lint` for invoking `swift-format lint` with the default options
- `swift-lint-strict` for invoking `swift-format lint --strict`